### PR TITLE
Fix acu item checks

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -491,6 +491,8 @@ E boolean FDECL(obj_summon_out, (struct obj *));
 E int NDECL(doddrop);
 E int NDECL(dodown);
 E int NDECL(doup);
+E int NDECL(acu_asc_items_check);
+E void FDECL(acu_asc_items_warning, (int));
 #ifdef INSURANCE
 E void NDECL(save_currentstate);
 #endif

--- a/src/potion.c
+++ b/src/potion.c
@@ -1033,6 +1033,16 @@ peffects(otmp)
 	case POT_GAIN_LEVEL:
 		if (otmp->cursed) {
 			unkn++;
+			if (Role_if(PM_ANACHRONOUNBINDER)
+					&& u.uhave.amulet
+					&& ledger_no(&u.uz) == 1) {
+				int missing_items = acu_asc_items_check();
+				if (missing_items) {
+					You("have an uneasy feeling.");
+					acu_asc_items_warning(missing_items);
+					break;
+				}
+			}
 			/* they went up a level */
 			if((ledger_no(&u.uz) == 1 && u.uhave.amulet) ||
 				Can_rise_up(u.ux, u.uy, &u.uz)) {

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1197,6 +1197,15 @@ register struct trap *ttmp;
 	    You_feel("dizzy for a moment, but nothing happens...");
 	    return;
 	}
+
+	if (In_endgame(&u.uz) && Role_if(PM_ANACHRONOUNBINDER)) {
+		int missing_items = acu_asc_items_check();
+		if (missing_items) {
+			You("stop yourself from entering.");
+			acu_asc_items_warning(missing_items);
+			return;
+		}
+	}
 	
 	//The exit portal tries to return fem half dragon nobles to where they entered the quest.
 	if(Role_if(PM_NOBLEMAN) && Race_if(PM_HALF_DRAGON) && flags.initgend && In_quest(&u.uz)){


### PR DESCRIPTION
This tweaks the acuOK method, creates a warning method, then uses that for checking portals between the planes and cursed gain level

Fixes #34 
Fixes #33 