### PR TITLE
Put the items in Kroo's in the chests

### DIFF
--- a/dat/dismalswamp.des
+++ b/dat/dismalswamp.des
@@ -170,38 +170,40 @@ GOLD: random,random
 GOLD: random,random
 GOLD: random,random
 MONSTER: 'B',"giant bat", (43,11), hostile, asleep
-OBJECT:'(',"chest",(45,12)
+CONTAINER:'(',"chest",(45,12)
 GOLD: random,(45,12)
 GOLD: random,(45,12)
 GOLD: random,(45,12)
 OBJECT: '(',"pick-axe",(31,13)
-OBJECT: '*',random,(45,12)
-OBJECT: '/',random,(45,12)
-OBJECT: '*',random,(45,12)
+OBJECT: '*',random,contained
+OBJECT: '/',random,contained
+OBJECT: '*',random,contained
 MONSTER: 'B',"giant bat", (65,13), hostile, asleep
-OBJECT:'(',"chest",(65,13)
+CONTAINER:'(',"chest",(65,13)
 GOLD: random,(65,13)
 GOLD: random,(65,13)
-OBJECT: '*',random,(65,13)
-OBJECT: '*',random,(65,13)
-OBJECT: '*',random,(65,13)
+OBJECT: '*',random,contained
+OBJECT: '*',random,contained
+OBJECT: '*',random,contained
+OBJECT: '!',random,contained
 MONSTER: 's',"giant spider", (67,1), hostile, asleep
+CONTAINER:'(',"chest",(68,2)
 GOLD: random,(68,2)
 GOLD: random,(68,2)
 GOLD: random,(68,2)
-OBJECT: '*',random,(68,2)
-OBJECT: '*',random,(68,2)
-OBJECT: '*',random,(68,2)
-OBJECT:'(',"chest",(68,2)
+OBJECT: '*',random,contained
+OBJECT: '*',random,contained
+OBJECT: '*',random,contained
+OBJECT: '+',random,contained
 OBJECT:'(',"chest",(2,1)
 OBJECT:'(',"chest",(3,1)
 OBJECT:'(',"chest",(4,1)
-OBJECT:'(',"chest",(18,14)
-OBJECT: ')',random,(18,14)
-OBJECT: ')',random,(18,14)
+CONTAINER:'(',"chest",(18,14)
+OBJECT: ')',random,contained
+OBJECT: ')',random,contained
 OBJECT: '/',random,(18,14)
-OBJECT: '[',random,(18,14)
-OBJECT: '[',random,(18,14)
+OBJECT: '[',random,contained
+OBJECT: '[',random,contained
 OBJECT: '!',random,(18,14)
 OBJECT: '!',random,(18,14)
 MONSTER: '@', "armorsmith", random, peaceful


### PR DESCRIPTION
Just like the tomb des file the items were being placed beneath the chests.

I left the potions and wands that Kroo starts on alone so he can still be occasionally extra nasty.

This is a minor nerf to the player losing several random chest contents worth of loot, but dismal swamp is the best anyway.

I added a guaranteed potion and spellbook to the far right chests in order to preserve a (minor) reason to actually go over there.