### PR TITLE
Fix the second-to-last spire tower's orientation

### DIFF
--- a/dat/dngnch1.def
+++ b/dat/dngnch1.def
@@ -331,7 +331,7 @@ LEVEL:          "lbyrnth" "none" @ (1, 0)
 
 
 ##
-DUNGEON:        "The Spire" "none" (14, 0)
+DUNGEON:        "The Spire" "none" (15, 0)
 ALIGNMENT:      neutral
 DESCRIPTION:    mazelike
 ENTRY:		-1
@@ -348,7 +348,8 @@ LEVEL:          "stairs2" "none" @ (10, 0)
 LEVEL:          "stairs1" "none" @ (11, 0)
 LEVEL:          "stairs2" "none" @ (12, 0)
 LEVEL:          "stairs1" "none" @ (13, 0)
-LEVEL:          "stairs3" "none" @ (14, 0)
+LEVEL:          "stairs2" "none" @ (14, 0)
+LEVEL:          "stairs3" "none" @ (15, 0)
 
 
 #

--- a/dat/dngnch2.def
+++ b/dat/dngnch2.def
@@ -329,7 +329,7 @@ LEVEL:          "lbyrnth" "none" @ (1, 0)
 
 
 ##
-DUNGEON:        "The Spire" "none" (14, 0)
+DUNGEON:        "The Spire" "none" (15, 0)
 ALIGNMENT:      neutral
 DESCRIPTION:    mazelike
 ENTRY:		-1
@@ -346,7 +346,8 @@ LEVEL:          "stairs2" "none" @ (10, 0)
 LEVEL:          "stairs1" "none" @ (11, 0)
 LEVEL:          "stairs2" "none" @ (12, 0)
 LEVEL:          "stairs1" "none" @ (13, 0)
-LEVEL:          "stairs3" "none" @ (14, 0)
+LEVEL:          "stairs2" "none" @ (14, 0)
+LEVEL:          "stairs3" "none" @ (15, 0)
 
 
 #

--- a/dat/dngnch3.def
+++ b/dat/dngnch3.def
@@ -337,7 +337,7 @@ LEVEL:          "lbyrnth" "none" @ (1, 0)
 
 
 ##
-DUNGEON:        "The Spire" "none" (14, 0)
+DUNGEON:        "The Spire" "none" (15, 0)
 ALIGNMENT:      neutral
 DESCRIPTION:    mazelike
 ENTRY:		-1
@@ -354,7 +354,8 @@ LEVEL:          "stairs2" "none" @ (10, 0)
 LEVEL:          "stairs1" "none" @ (11, 0)
 LEVEL:          "stairs2" "none" @ (12, 0)
 LEVEL:          "stairs1" "none" @ (13, 0)
-LEVEL:          "stairs3" "none" @ (14, 0)
+LEVEL:          "stairs2" "none" @ (14, 0)
+LEVEL:          "stairs3" "none" @ (15, 0)
 
 
 #


### PR DESCRIPTION
The intended alternation between stairs1 and stairs2 works fine, but when changing from stairs3 to stairs1 the orientation was wrong.

This adds an extra floor to the staircase to fix that.