### PR TITLE
Make LIMIT_IPS a compile-time option

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -236,7 +236,13 @@
  */
 #endif /* CHDIR */
 
-
+/*
+ * Limits the game to at most 100 inputs per second, and command
+ * repeats to 200.  This should be enabled on hardfought to avoid the
+ * high CPU usage kill script, but not when playing locally or CPU
+ * usage is properly limited with cgroups.
+ */
+/* #define LIMIT_IPS */
 
 /*
  * Section 3:	Definitions that may vary with system type.

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -1678,7 +1678,9 @@ moveloop()
 	// printBodies();
 	// printSanAndInsight();
     for(;;) {/////////////////////////MAIN LOOP/////////////////////////////////
+#ifdef LIMIT_IPS
 	if (!iflags.debug_fuzzer) gosleep();
+#endif
     hpDiff = u.uhp;
 	get_nh_event();
 #ifdef POSITIONBAR

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -3,6 +3,7 @@
 /* NetHack may be freely redistributed.  See license for details. */
 
 #include <ctype.h>
+#include <limits.h>
 
 #include "hack.h"
 #include "artifact.h"
@@ -4678,8 +4679,11 @@ parse()
 	    for (;;) {
 		foo = readchar();
 		if (foo >= '0' && foo <= '9') {
-		    multi = 10 * multi + foo - '0';
-		    if (multi < 0 || multi >= 200) multi = 200;
+		    if (ckd_mul(&multi, 10, multi)) multi = INT_MAX;
+		    else if (ckd_add(&multi, multi, foo - '0')) multi = INT_MAX;
+#ifdef LIMIT_IPS
+		    if (multi > 200) multi = 200;
+#endif
 		    if (multi > 9) {
 			clear_nhwindow(WIN_MESSAGE);
 			Sprintf(in_line, "Count: %d", multi);


### PR DESCRIPTION
Disabled by default.  This should be enabled in local.mk in the hardfought build.  Limiting command repeats and instructions per second is annoying and unnecessary when playing locally or with proper CPU usage limiting (cgroups).